### PR TITLE
fix: add support for v4l2-loopback

### DIFF
--- a/camset/camset.py
+++ b/camset/camset.py
@@ -381,15 +381,19 @@ def read_capabilites(card):
         # menu options
         else: 
             if line:
-                # map index to value
-                value = int(line.split(": ", 1)[0]) # get value from text because index is not (always) same as value
-                win.ctrl_store.append ([line])
-                # count index, set active
-                index = 0
-                for item in win.ctrl_store:
-                    index += 1
-                if value == menvalue:
-                    win.ctrl_combobox.set_active(index - 1)
+                try:
+                    # map index to value
+                    value = int(line.split(": ", 1)[0]) # get value from text because index is not (always) same as value
+                    win.ctrl_store.append ([line])
+                    # count index, set active
+                    index = 0
+                    for item in win.ctrl_store:
+                        index += 1
+                    if value == menvalue:
+                        win.ctrl_combobox.set_active(index - 1)
+                except ValueError:
+                    # E.g. v4l2loopback has 'User Controls' output
+                    pass
 
     read_resolution_capabilites(card)
     win.show_all()


### PR DESCRIPTION
v4l2-loopback devices emit a spurious 'User Controls' message:
```
$ v4l2-ctl -d /dev/video20 -L

User Controls

                    keep_format 0x0098f900 (bool)   : default=0 value=0
              sustain_framerate 0x0098f901 (bool)   : default=0 value=0
                        timeout 0x0098f902 (int)    : min=0 max=100000 step=1 default=0 value=0
               timeout_image_io 0x0098f903 (bool)   : default=0 value=0
```

ignore and continue in the parsing.